### PR TITLE
[qfix] Change setup-gcloud action tag 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           go-version: 1.16
       - name: Install gcloud-sdk
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/googleapis/gnostic v0.5.1 // indirect
-	github.com/networkservicemesh/integration-tests v0.0.0-20220321164838-5f79ce6dd98c
+	github.com/networkservicemesh/integration-tests v0.0.0-20220322220243-c103f3dda0e5
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/client-go v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/networkservicemesh/gotestmd v0.0.0-20211116145945-871d2aaf07ab h1:/dIr8Nky77grI3s9Rc78eFH9M1Svobyj2XJBaKm27ts=
 github.com/networkservicemesh/gotestmd v0.0.0-20211116145945-871d2aaf07ab/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
-github.com/networkservicemesh/integration-tests v0.0.0-20220321164838-5f79ce6dd98c h1:cyKv6yEbvIBmF6cX1kT37hwc3uBhKRaAynZ2M1esmlU=
-github.com/networkservicemesh/integration-tests v0.0.0-20220321164838-5f79ce6dd98c/go.mod h1:0o7WrzxlHEwnDSuZPEM1BnKd4hr7+akKgymoAoTTbv8=
+github.com/networkservicemesh/integration-tests v0.0.0-20220322220243-c103f3dda0e5 h1:feVxYR2QsVMavgr0RXRwOlLCnf8oI4n1oE6cNe4S1WQ=
+github.com/networkservicemesh/integration-tests v0.0.0-20220322220243-c103f3dda0e5/go.mod h1:0o7WrzxlHEwnDSuZPEM1BnKd4hr7+akKgymoAoTTbv8=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Because of: https://github.com/google-github-actions/setup-gcloud

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>