### PR TITLE
Add vl3 tests to excluded tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -41,9 +41,13 @@ func TestRunFeatureSuite(t *testing.T) {
 		parallel.WithRunningTestsSynchronously(
 			featuresSuite.TestScale_from_zero,
 			featuresSuite.TestVl3_dns,
-			featuresSuite.TestVl3_scale_from_zero,
 			featuresSuite.TestNse_composition,
-			featuresSuite.TestSelect_forwarder))
+			featuresSuite.TestSelect_forwarder,
+			featuresSuite.TestVl3_scale_from_zero,
+			featuresSuite.TestVl3_ipv6,
+			featuresSuite.TestVl3_dual_stack,
+			featuresSuite.TestVl3_lb,
+			featuresSuite.TestScaled_registry))
 }
 
 func TestRunBasicSuite(t *testing.T) {


### PR DESCRIPTION
## Description
`vl3` tests conflict with `scaled registry` tests. `vl3` endpoints can't register themselves because `scaled registry` test deletes registries
## Issue
https://github.com/networkservicemesh/integration-k8s-aws/actions/runs/10179324617/job/28154806977